### PR TITLE
added custom error class so activation/error detail is not swallowed

### DIFF
--- a/lib/base_operation.js
+++ b/lib/base_operation.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const messages = require('./messages')
+const BaseOperationError = require('./base_operation_error')
 const rp = require('request-promise')
 
 class BaseOperation {
@@ -59,10 +60,16 @@ class BaseOperation {
           throw new Error(messages.CREATE_CONFLICT_ERROR)
         default:
           let error = 'Missing error message.'
-          if (reason.error && reason.error.response && reason.error.response.result && reason.error.response.result.error) {
-            error = reason.error.response.result.error
+          if (reason.error) {
+            if (reason.error.response && reason.error.response.result && reason.error.response.result.error) {
+              error = reason.error.response.result.error
+            }
+            throw new BaseOperationError(`${messages.API_SYSTEM_ERROR} ${error}`, reason.error);
           }
-          throw new Error(`${messages.API_SYSTEM_ERROR} ${error}`)
+          else {
+            throw new Error(`${messages.API_SYSTEM_ERROR} ${error}`) 
+          }
+          
       }
     }
 

--- a/lib/base_operation_error.js
+++ b/lib/base_operation_error.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = function BaseOperationError(message, error) {
+  Error.captureStackTrace(this, this.constructor);
+  this.name = this.constructor.name;
+  this.message = message;
+  this.error = error;
+};
+
+require('util').inherits(module.exports, Error);


### PR DESCRIPTION
Added a custom error class so that details about the activation are not hidden at the API level.  This takes the "error" object that is caught in base_operation.js and attaches it to the custom error object so we can access logs and the activationId:

![image](https://cloud.githubusercontent.com/assets/974294/15258675/e858f77e-191a-11e6-930f-69d1a84db5a0.png)
