### PR TITLE
Fix actions.get to support packaged actions

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -61,7 +61,7 @@ class Actions extends BaseOperation {
 
   action (method, options) {
     const action = options.actionName
-    const namespace = this.namespace(options)
+    const namespace = encodeURIComponent(this.namespace(options))
     const params = this.params(method, `namespaces/${namespace}/actions/${action}`)
 
     if (!action) {


### PR DESCRIPTION
For packaged actions, the namespace will contain a slash character. we need to encodeURIComponent in order to handle this case properly.

closes #7