### PR TITLE
If apihost already is fully qualified with a protocol, use it

### DIFF
--- a/lib/base_operation.js
+++ b/lib/base_operation.js
@@ -29,10 +29,15 @@ class BaseOperation {
 
   url_from_apihost (apihost) {
     if (!apihost) return apihost
+    const apipath = '/api/v1/'
+    var protocol = ''
 
-    const is_http = apihost.includes(':') && !apihost.includes(':443')
-    const protocol = is_http ? 'http' : 'https'
-    return `${protocol}://${apihost}/api/v1/`
+    // if apihost already is fully qualified with a protocol, use it as is
+    // else assume https
+    if (!apihost.startsWith('https://') && !apihost.startsWith('http://')) {
+        protocol = 'https://'
+    }
+    return `${protocol}${apihost}${apipath}`
   }
 
   request (options) {


### PR DESCRIPTION
I'm making a change on the openwhisk side so that the api host always contains the protocol. This make the inference here unnecessary (and will cause some breakage).